### PR TITLE
Refactor SystemDataRecorder for improved parameter handling and multi session management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10...3.27)
 project(system_data_recorder)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -53,6 +53,11 @@ install(TARGETS
   system_data_recorder
   DESTINATION lib/${PROJECT_NAME}
 )
+
+# Install launch, config directories
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/README.md
+++ b/README.md
@@ -1,129 +1,159 @@
 # System Data Recorder (SDR)
 
-
-A lifecycle node and executable for recording topic data to a rosbag2 bag, while simultaneously copying the split bag files to another location as each bag file is completed.
+A lifecycle node for recording multiple, distinct rosbag2 bags sessions, while simultaneously copying the split bag files to another location as each bag file is completed.
 This is useful, for example, to copy bag data files to an external disc during recording as each data file is completed, rather than waiting until all data is recorded before copying the entire bag at once (an operation that can take a significant time if the bag is large).
 
 The copying function requires that a maximum file size for bag files be enabled.
 Otherwise no splitting will be performed and the files will not be copied until recording is terminated.
 
+## Configuration
 
-## Compilation
+The SDR is configured using a YAML parameter file, which is loaded via a ROS 2 launch file. This is the recommended way to run the node.
 
-The SDR requires two features not yet available in the rosbag2 main branch or binary releases.
-You will need to compile rosbag2 from source, applying the following two pull requests to the source prior to compiling it.
+#### Parameters
 
-1. [Expose the QoS object wrapper](https://github.com/ros2/rosbag2/pull/910)
-2. [Notification of significant events during bag recording and playback](https://github.com/ros2/rosbag2/pull/908)
+* `bag_name_prefix` (string): The base name for each bag file. A timestamp will be appended to this (e.g., `"recording"` becomes `"recording_2025-07-10_02-30-00"`).
+* `copy_destination` (string): The parent directory where all recording session folders will be saved.
+* `max_file_size` (int): The maximum size in bytes for an individual `.db3` file before it is split. A value greater than `0` is required for the copy-on-split feature to work.
+* `topic_names` (string array): A list of topics to record.
+* `topic_types` (string array): A corresponding list of message types for the topics.
 
-Create a `colcon` workspace with the [SDR source code](https://github.com/osrf/system_data_recorder) in it, and compile the workspace.
+#### Example `sdr_example.yaml`
 
+```yaml
+sdr:
+  ros__parameters:
+    # The base name for each bag file. A timestamp will be appended to this.
+    bag_name_prefix: "robot_data"
+
+    # The parent directory where all recording session folders will be saved.
+    copy_destination: "/home/user/sdr_bags"
+
+    # Maximum size of each individual .db3 file in bytes before splitting.
+    max_file_size: 268435456  # 256 MiB
+
+    # List of topics and their types to record.
+    topic_names: [
+      "/chatter",
+      "/diagnostics"
+    ]
+    topic_types: [
+      "std_msgs/msg/String",
+      "diagnostic_msgs/msg/DiagnosticArray"
+    ]
+```
 
 ## Use
 
 ### Lifecycle management
 
-Run the executable to start the node.
+Run the executable using a launch file that loads your parameters. For example:
+`ros2 launch system_data_recorder sdr_example.launch.py`
 
-    ros2 run system_data_recorder system_data_recorder
+In a separate terminal, use the lifecycle manager to control the node.
 
-In a separate terminal, use the lifecycle manager to configure and activate the node.
+1. **Configure the node.**
+This sets up the main session directory and prepares the node for recording. This is done only once.
 
-    ros2 lifecycle set sdr configure
-    ros2 lifecycle set sdr activate
+```bash
+ros2 lifecycle set /sdr configure
+```
 
-This will enable recording of data to the bag.
-To pause recording, deactivate the node.
+2. **Activate to start recording.**
+This begins a new, timestamped bag recording.
 
-    ros2 lifecycle set sdr deactivate
+```bash
+ros2 lifecycle set /sdr activate
+```
 
-From here, recording can be resumed by re-activating the node, or recording can be terminated by cleaning up the node.
+3. **Deactivate to stop recording.**
+This finalizes the current bag and copies its files to the permanent destination.
 
-    ros2 lifecycle set sdr cleanup
+```bash
+ros2 lifecycle set /sdr deactivate
+```
 
-Once cleaned up, the node will copy the final files of the bag, as well as any metadata, to the backup destination.
+You can repeat steps 2 and 3 as many times as you like to create multiple, separate bag files within the same run.
 
-### Configuring
+4. **Cleanup the node.**
+This stops the background threads and cleans up resources.
 
-The SDR is configured by the arguments passed to the node's constructor.
-These are not currently exposed as command line arguments or ROS parameters, so they must be changed in the source code.
-See the constructor's documentation block for the possible parameters.
+```bash
+ros2 lifecycle set /sdr cleanup
+```
 
-By default, the SDR will:
+5. **Shutdown the node.**
 
-- Record from the `/chatter` topic, expecting `std_msgs/msg/String` data.
-- Record to a bag named `test_bag`.
-- Copy bag files to the directory `copied_bag/test_bag`.
-- Split bag files every 100,000 bytes.
+```bash
+ros2 lifecycle set /sdr shutdown
+```
 
-### A simple test
+### A Simple Test
 
-In one terminal, start publishing data on the `/chatter` topic.
+1. In one terminal, start publishing data:
 
-    ros2 run demo_nodes_cpp talker
+```bash
+ros2 launch system_data_recorder sdr_example.launch.py
+```
 
-In another terminal, start the SDR node.
+2. In another terminal, launch the SDR node with your parameters:
 
-    ros2 run system_data_recorder system_data_recorder
+```bash
+ros2 launch your_package_name your_launch_file.py
+```
 
-In a third terminal, configure and activate the SDR.
+3. In a third terminal, configure the SDR, then activate it to start the first recording:
 
-    ros2 lifecycle set sdr configure
-    ros2 lifecycle set sdr activate
+```bash
+ros2 lifecycle set /sdr configure
+ros2 lifecycle set /sdr activate
+```
 
-Wait a minute or two for 100,000 bytes of data to be recorded.
-Navigate to the directory `copied_bag` and observe that there is a `test_bag`
-directory containing the first data file of the bag.
+4. After some time, deactivate it to save the first bag:
 
-Deactivate and cleanup the SDR.
+```bash
+ros2 lifecycle set /sdr deactivate
+```
 
-    ros2 lifecycle set sdr deactivate
-    ros2 lifecycle set sdr cleanup
+5. Activate it again to start a second, new recording:
 
-Again navigate to the `copied_bag` directory, and observe that the `test_bag`
-directory now contains all the data files of the bag, and a `metadata.yaml`
-file.
+```bash
+ros2 lifecycle set /sdr activate
+```
 
-This is a complete, usable bag.
-This can be demonstrated by stopping the `talker` node, then starting the
-`listener` node and playing the bag file.
+6. Deactivate and clean up:
 
-    ros2 run demo_nodes_cpp listener
-    ros2 bag play copied_bag/test_bag
+```bash
+ros2 lifecycle set /sdr deactivate
+ros2 lifecycle set /sdr cleanup
+```
 
-The recorded data will be echoed by the `listener` node.
+Now, navigate to your `copy_destination` directory (e.g., `/home/user/sdr_bags`). You will find a main session folder (e.g., `sdr_session_2025-07-10_03-00-00`), and inside it will be two complete, timestamped bag directories from your two recording sessions.
 
+You can play back one of the bags:
 
-## Lifecycle transition behaviours
+```bash
+ros2 bag play /home/user/sdr_bags/sdr_session_.../robot_data_...
+```
+
+## Lifecycle Transition Behaviours
 
 ### on_configure
 
-In the on_configure state, the node sets up the rosbag2 infrastructure for
-recording by creating a writer and opening the storage. It also sets up the
-worker thread that will copy files in parallel to the recording of data. A
-callback is registered with the writer so that the node will get informed each
-time a new file is created in the bag.
+Creates the main, timestamped session directory that will contain all bags recorded during this run. It also starts the background file-copying thread. **It does not start any recording.**
 
 ### on_activate
 
-In the on_activate transition, the node simply notifies the worker thread that
-it is recording. Data will be written to the bag automatically because the
-state changes to `Active`.
+Begins a **new, unique recording session**. It creates a timestamped bag, sets up a temporary storage location, initializes a `rosbag2::Writer`, and subscribes to the requested topics. Data begins being written to the temporary bag file.
 
 ### on_deactivate
 
-In the on_deactivate transition, the node simply notifies the worker thread
-that it is paused. Data will not be written to the bag because the state
-changes to `Inactive`.
+**Finalizes the current recording session**. It unsubscribes from topics, closes the `rosbag2::Writer` (which flushes all data to disk and writes the `metadata.yaml` file), and queues the final bag files to be copied to their permanent destination within the main session folder.
 
 ### on_cleanup
 
-When cleaning up, the node needs to stop recording, stop receiving data (i.e.
-unsubscribe from topics), and ensure that the final files of the bag (the last
-data file and the metadata file, which gets written when the writer object
-destructs) are copied to the destination directory.
+Ensures the last active recording session is properly deactivated and finalized. It then gracefully shuts down the background copy thread.
 
 ### on_shutdown
 
-If not already performed, the shutdown transition performs the same functions
-as the cleanup transition.
+Performs the same actions as `on_cleanup` before shutting down the node.

--- a/config/sdr_example.yaml
+++ b/config/sdr_example.yaml
@@ -1,0 +1,18 @@
+sdr:  
+  ros__parameters:
+    # The base name for each bag file. A timestamp will be appended to this.
+    bag_name_prefix: "robot_data"
+
+    # The parent directory where all recording session folders will be saved.
+    copy_destination: "/home/user/sdr_bags"
+
+    # Maximum size of each individual .db3 file in bytes before splitting.
+    max_file_size: 268435456  # 256 MiB
+
+    # List of topics and their types to record.
+    topic_names: [
+      "/chatter",
+    ]
+    topic_types: [
+      "std_msgs/msg/String",
+    ]

--- a/launch/sdr_example.launch.py
+++ b/launch/sdr_example.launch.py
@@ -1,0 +1,24 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    # Get the path to the package
+    sdr_pkg_path = get_package_share_directory('system_data_recorder') # <-- CHANGE 'your_package_name'
+
+    # Get the path to the YAML file
+    config_file_path = os.path.join(sdr_pkg_path, 'config', 'sdr_example.yaml')
+
+    # Create the node action
+    sdr_node = Node(
+        package='system_data_recorder', # <-- CHANGE 'your_package_name'
+        executable='system_data_recorder', # <-- CHANGE to your C++ executable name from CMakeLists.txt
+        name='sdr',
+        output='screen',
+        parameters=[config_file_path]
+    )
+
+    return LaunchDescription([
+        sdr_node
+    ])

--- a/src/sdr_component.cpp
+++ b/src/sdr_component.cpp
@@ -14,6 +14,7 @@
 
 #include "sdr/sdr_component.hpp"
 
+#include <filesystem>
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag2_transport/qos.hpp"
@@ -22,449 +23,480 @@
 namespace sdr
 {
 
-SystemDataRecorder::SystemDataRecorder(
-  const std::string & node_name,
-  const rclcpp::NodeOptions & options,
-  const std::string & bag_uri,
-  const std::string & copy_destination,
-  const unsigned int max_file_size,
-  const std::unordered_map<std::string, std::string> & topics_and_types)
-: rclcpp_lifecycle::LifecycleNode(node_name, options),
-  topics_and_types_(topics_and_types),
-  source_directory_(bag_uri)
-{
-  // Set up the storage options for writing the bag
-  storage_options_.uri = bag_uri;
-  // Only the "sqlite3" storage backend is supported; currently this is the only backend provided
-  // by rosbag2 so this is not a problem at this time
-  storage_options_.storage_id = "sqlite3";
-  // Set the maximum size of each individual file
-  storage_options_.max_bagfile_size = max_file_size;
-  // Using a write cache is not required, but it helps avoid disc I/O becoming a bottleneck.
-  // Set this option to 0 to disable the cache
-  storage_options_.max_cache_size = 100*1024*1024;
-
-  // Get the name of the bag directory from the bag URI - the bag URI should not be empty
-  auto bag_directory_name = std::filesystem::path(bag_uri).filename();
-  if (bag_directory_name.empty()) {
-    // There was probably a slash on the end
-    std::string bag_uri_copy = bag_uri;
-    bag_directory_name = std::filesystem::path(
-      bag_uri_copy.erase(bag_uri.size() - 1, 1)).filename();
-  }
-  // A directory named after the bag will be created under the copy_destination directory to put
-  // the copied files into
-  destination_directory_ = std::filesystem::path(copy_destination) / bag_directory_name;
-
-  // Initially, the "last" bag file will be the first bag file
-  last_bag_file_ = std::filesystem::path(bag_uri) / bag_directory_name.concat("_0.db3");
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Lifecycle states
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-// In the on_configure state, we set up the rosbag2 infrastructure for recording by creating a
-// writer and opening the storage. We also set up the worker thread that will copy files in
-// parallel to the recording of data. A callback is registered with the writer so that we will get
-// informed each time a new file is created in the bag.
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemDataRecorder::on_configure(const rclcpp_lifecycle::State & /* state */)
-{
-  RCLCPP_INFO(get_logger(), "Preparing to begin recording");
-
-  RCLCPP_INFO(get_logger(), "Copying bag files to %s", destination_directory_.c_str());
-
-  // Prepare for file-copying by creating the destination directory and setting up a worker thread
-  try {
-    if (!create_copy_destination()) {
-      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
-    }
-  }
-  catch (std::filesystem::filesystem_error const & ex) {
-    RCLCPP_ERROR(get_logger(), "Could not create destination directory for bag backup");
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
-  }
-  copy_thread_ = std::make_shared<std::thread>([this]{ copy_thread_main(); });
-
-  // Notify the copy thread to get it into the correct state
-  notify_state_change(SdrStateChange::PAUSED);
-
-  // Prepare the rosbag2 objects for recording
-  // A sequential writer is used as this is the only writer currently available
-  writer_ = std::make_shared<rosbag2_cpp::Writer>(
-    std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
-  // Add a callback for when a split occurs
-  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
-  callbacks.write_split_callback =
-    [this]
-    (rosbag2_cpp::bag_events::BagSplitInfo & info) {
-      // Record the opened file - this will be the last file remaining to be copied when recording
-      // is terminated
-      last_bag_file_ = info.opened_file;
-      // Notify the worker thread about the closed file being ready to copy
-      notify_new_file_to_copy(info.closed_file);
-    };
-  writer_->add_event_callbacks(callbacks);
-  // Open the bag
-  writer_->open(
-    storage_options_,
-    {rmw_get_serialization_format(), rmw_get_serialization_format()});
-
-  // Start receiving data - it won't be recorded yet because the node's lifecycle is not in the
-  // Active state
-  subscribe_to_topics();
-
-  // Make sure cleanup happens when the on_cleanup transition occurs - this allows the node to be
-  // cleaned up and then configured again (with the bag files moved away somewhere else) without
-  // shutting it down
-  cleaned_up = false;
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
-// In the on_activate transition, we simply notify the worker thread that we are recording. Data
-// will be written to the bag because the state changes to Active.
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemDataRecorder::on_activate(const rclcpp_lifecycle::State & /* state */)
-{
-  RCLCPP_INFO(get_logger(), "Starting recording");
-
-  // Notify the copy thread
-  notify_state_change(SdrStateChange::RECORDING);
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
-// In the on_deactivate transition, we simply notify the worker thread that we are paused. Data
-// will not be written to the bag because the state changes to Inactive.
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemDataRecorder::on_deactivate(const rclcpp_lifecycle::State & /* state */)
-{
-  RCLCPP_INFO(get_logger(), "Pausing recording");
-
-  // Notify the copy thread
-  notify_state_change(SdrStateChange::PAUSED);
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
-// When cleaning up, we need to stop recording, stop receiving data (i.e. unsubscribe from topics),
-// and ensure that the final files of the bag (the last data file and the metadata file, which gets
-// written when the writer object destructs) are copied to the destination directory.
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemDataRecorder::on_cleanup(const rclcpp_lifecycle::State & /* state */)
-{
-  RCLCPP_INFO(get_logger(), "Stopping and finalising recording");
-  // Avoid double-cleanup if on_shutdown is called after this
-  cleaned_up = true;
-
-  // Stop recording by stopping data from arriving
-  unsubscribe_from_topics();
-  // Clean up the writer so that the bag is closed and the metadata file is written
-  writer_.reset();
-  // Copy the final data file
-  notify_new_file_to_copy(last_bag_file_);
-  // Copy the metadata file
-  notify_new_file_to_copy(source_directory_ / "metadata.yaml");
-
-  // Notify the worker thread that we are cleaning up, so that it exits onces it's finished its
-  // final work
-  notify_state_change(SdrStateChange::FINISHED);
-  copy_thread_->join();
-  // Get rid of the worker thread
-  copy_thread_.reset();
-
-  RCLCPP_INFO(get_logger(), "Cleanup complete");
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
-// If not already performed, the shutdown transition performs the same functions as the cleanup
-// transition.
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemDataRecorder::on_shutdown(const rclcpp_lifecycle::State & /* state */)
-{
-  RCLCPP_INFO(get_logger(), "Stopping and finalising recording (hard shutdown)");
-  if (!cleaned_up) {
-    // Stop recording
-    unsubscribe_from_topics();
-    // Clean up the writer
-    writer_.reset();
-    // Copy the final file
-    notify_new_file_to_copy(last_bag_file_);
-    // Copy the metadata file
-    notify_new_file_to_copy(source_directory_ / "metadata.yaml");
-  }
-
-  // Notify the copy thread - but only if it hasn't already been cleaned up
-  if (copy_thread_) {
-    notify_state_change(SdrStateChange::FINISHED);
-    copy_thread_->join();
-    copy_thread_.reset();
-  }
-  RCLCPP_INFO(get_logger(), "Cleanup complete");
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Bag recording functionality
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-void SystemDataRecorder::subscribe_to_topics()
-{
-  for (const auto & topic_with_type : topics_and_types_) {
-    subscribe_to_topic(topic_with_type.first, topic_with_type.second);
-  }
-}
-
-void SystemDataRecorder::subscribe_to_topic(const std::string & topic, const std::string & type)
-{
-  // Get the QoS offered by the topic for saving in the bag
-  auto offered_qos = get_serialised_offered_qos_for_topic(topic);
-  // Find out what QoS is most appropriate to use when subscribing to the topic
-  auto qos = get_appropriate_qos_for_topic(topic);
-
-  // The metadata to pass to the writer object so it can register the topic in the bag
-  auto topic_metadata = rosbag2_storage::TopicMetadata(
+    SystemDataRecorder::SystemDataRecorder(const rclcpp::NodeOptions &options)
+        : rclcpp_lifecycle::LifecycleNode("sdr", options)
     {
-      topic,  // Topic name
-      type,  // Topic type, e.g. "example_interfaces/msg/String"
-      rmw_get_serialization_format(),  // The serialization format, most likely to be "CDR"
-      offered_qos  // The offered QoS profile for the topic in YAML
-    }
-  );
-  // It is a good idea to create the topic in the writer prior to adding the subscription in case
-  // data arrives after subscribing and before the topic is created. Although we should be ignoring
-  // any data until the node is set to active, we maintain this good practice here for future
-  // maintainability.
-  writer_->create_topic(topic_metadata);
-
-  // Create a generic subscriber. A generic subscriber received message data in serialized form,
-  // which means that:
-  // - No de-serialization will take place, saving that processing time, and
-  // - The data type does not need to be known at compile time, so we don't need a templated
-  //   callback for when message data is received.
-  auto subscription = create_generic_subscription(
-    topic,
-    type,
-    qos,
-    [this, topic, type](std::shared_ptr<rclcpp::SerializedMessage> message) {
-      // When a message is received, it should only be written to the bag if recording is not
-      // paused (i.e. the node lifecycle state is "active"). If recording is paused, the message is
-      // thrown away.
-      if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-        writer_->write(message, topic, type, rclcpp::Clock(RCL_SYSTEM_TIME).now());
-      }
-    });
-  if (subscription) {
-    subscriptions_.insert({topic, subscription});
-    RCLCPP_INFO(get_logger(), "Subscribed to topic '%s'", topic.c_str());
-  } else {
-    writer_->remove_topic(topic_metadata);
-    RCLCPP_ERROR(get_logger(), "Failed to subscribe to topic '%s'", topic.c_str());
-  }
-}
-
-std::string SystemDataRecorder::get_serialised_offered_qos_for_topic(const std::string & topic)
-{
-  YAML::Node offered_qos_profiles;
-  auto endpoints = get_publishers_info_by_topic(topic);
-  for (const auto & endpoint : endpoints) {
-    offered_qos_profiles.push_back(rosbag2_transport::Rosbag2QoS(endpoint.qos_profile()));
-  }
-  return YAML::Dump(offered_qos_profiles);
-}
-
-// Figure out the most appropriate QoS for a given topic. This method tries to decide if
-// constrained QoS can be used, or if less-trustworthy QoS needs to be used to catch data from
-// every publisher.
-// Returns the QoS to use.
-rclcpp::QoS SystemDataRecorder::get_appropriate_qos_for_topic(const std::string & topic)
-{
-  auto qos = rclcpp::QoS(rmw_qos_profile_default.depth);
-
-  // Get the information about known publishers on this topic
-  auto endpoints = get_publishers_info_by_topic(topic);
-  if (endpoints.empty()) {
-    // There are not yet any publishers on the topic.
-    // Use the default QoS profile, as we do not know what publishers will use since there are not
-    // yet any publishers on this topic.
-    return qos;
-  }
-
-  // Count the number of reliable and transient-local publishers for the topic
-  size_t reliability_reliable_endpoints_count = 0;
-  size_t durability_transient_local_endpoints_count = 0;
-  for (const auto & endpoint : endpoints) {
-    const auto & profile = endpoint.qos_profile().get_rmw_qos_profile();
-    if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
-      ++reliability_reliable_endpoints_count;
-    }
-    if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
-      ++durability_transient_local_endpoints_count;
-    }
-  }
-
-  if (reliability_reliable_endpoints_count == endpoints.size()) {
-    // All publishers are reliable, so we can use the reliable QoS
-    qos.reliable();
-  } else {
-    if (reliability_reliable_endpoints_count > 0) {
-      // There is a mix of QoS profiles amongst the publishers, so use the QoS setting that captures
-      // all of them
-      RCLCPP_WARN(
-        get_logger(),
-        "Some, but not all, publishers on topic \"%s\" are offering "
-          "RMW_QOS_POLICY_RELIABILITY_RELIABLE. Falling back to "
-          "RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT as it will connect to all publishers. Some "
-          "messages from Reliable publishers could be dropped.",
-        topic.c_str());
-    }
-    qos.best_effort();
-  }
-
-  if (durability_transient_local_endpoints_count == endpoints.size()) {
-    // All publishers are transient local, so we can use the transient local QoS
-    qos.transient_local();
-  } else {
-    if (durability_transient_local_endpoints_count > 0) {
-      // There is a mix of QoS profiles amongst the publishers, so use the QoS setting that captures
-      // all of them
-      RCLCPP_WARN(
-        get_logger(),
-        "Some, but not all, publishers on topic \"%s\" are offering "
-          "RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. Falling back to "
-          "RMW_QOS_POLICY_DURABILITY_VOLATILE as it will connect to all publishers. Previously-"
-          "published latched messages will not be retrieved.",
-        topic.c_str());
-    }
-    qos.durability_volatile();
-  }
-
-  return qos;
-}
-
-void SystemDataRecorder::unsubscribe_from_topics()
-{
-  // Make a note of the topics we are subscribed to
-  std::vector<rosbag2_storage::TopicMetadata> topics;
-  for (const auto & topic_with_type : topics_and_types_) {
-    topics.push_back(rosbag2_storage::TopicMetadata(
-      {
-        topic_with_type.first,
-        topic_with_type.second,
-        rmw_get_serialization_format(),
-        ""
-      }));
-  }
-  // Unsubscribing happens automatically when the subscription objects are destroyed
-  subscriptions_.clear();
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// File-copying thread
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-// The main function for the file-copying worker thread
-void SystemDataRecorder::copy_thread_main()
-{
-  RCLCPP_INFO(get_logger(), "Copy thread: Starting");
-  // Local state storage, to keep the critical section as short as possible
-  SdrStateChange current_state = SdrStateChange::PAUSED;
-  std::queue<std::string> local_files_to_copy;
-  // Loop until receiving a state-change message indicating it is time to stop
-  while (current_state != SdrStateChange::FINISHED)
-  {
-    { // Critical section start
-      std::unique_lock<std::mutex> lock(copy_thread_mutex_);
-      if (files_to_copy_.empty()) {
-        // Only wait if there's nothing to copy, otherwise skip the wait and go on
-        while (!copy_thread_should_wake()) {
-          copy_thread_wake_cv_.wait(lock);
+        RCLCPP_INFO(get_logger(), "Initializing SystemDataRecorder node...");
+        if (!read_parameters())
+        {
+            throw std::runtime_error("Failed to read parameters for SystemDataRecorder");
         }
-      }
-
-      // If the state has changed, make a note of the new state
-      if (state_msg_ != SdrStateChange::NO_CHANGE) {
-        current_state = state_msg_;
-        // Reset the message-carrying variable so we don't get confused the next time around the
-        // loop
-        state_msg_ = SdrStateChange::NO_CHANGE;
-      }
-
-      // local_files_to_copy_ will be empty here, so we are swapping the received queue of files
-      // and emptying the message-carrying queue at the same time
-      local_files_to_copy.swap(files_to_copy_);
-    } // Critical section end
-
-    // Now copy any files that were sent from the node
-    while(!local_files_to_copy.empty()) {
-      std::string uri = local_files_to_copy.front();
-      local_files_to_copy.pop();
-      copy_bag_file(uri);
     }
-  }
-  RCLCPP_INFO(get_logger(), "Copy thread: Exiting");
-}
 
-// Only wake up if there are files to copy or a state-change message has been received
-bool SystemDataRecorder::copy_thread_should_wake()
-{
-  return state_msg_ != SdrStateChange::NO_CHANGE || !files_to_copy_.empty();
-}
+    bool SystemDataRecorder::read_parameters()
+    {
+        // Declare parameters with new names
+        this->declare_parameter<std::string>("bag_name_prefix", "bag");
+        this->declare_parameter<std::string>("copy_destination", "");
+        this->declare_parameter<int>("max_file_size", 0);
+        this->declare_parameter<std::vector<std::string>>("topic_names", std::vector<std::string>{});
+        this->declare_parameter<std::vector<std::string>>("topic_types", std::vector<std::string>{});
 
-// Notify the worker thread of a state change by sending it a message and triggering its condition
-// variable
-void SystemDataRecorder::notify_state_change(SdrStateChange new_state)
-{
-  { // Critical section start
-    std::lock_guard<std::mutex> lock(copy_thread_mutex_);
-    // new_state must not be NO_CHANGE or the copy thread won't wake up
-    state_msg_ = new_state;
-  } // Critical section end
-  copy_thread_wake_cv_.notify_one();
-}
+        std::string copy_destination_str;
+        int max_file_size;
+        std::vector<std::string> topic_names, topic_types;
 
-// Notify the worker thread of a state change by adding the file to the queue and triggering its
-// condition variable
-void SystemDataRecorder::notify_new_file_to_copy(const std::string & file_uri)
-{
-  { // Critical section start
-    std::lock_guard<std::mutex> lock(copy_thread_mutex_);
-    files_to_copy_.push(file_uri);
-  } // Critical section end
-  copy_thread_wake_cv_.notify_one();
-}
+        if (!this->get_parameter("bag_name_prefix", base_bag_name_prefix_) || base_bag_name_prefix_.empty())
+        {
+            RCLCPP_FATAL(get_logger(), "Required parameter 'bag_name_prefix' not set or is empty.");
+            return false;
+        }
+        if (!this->get_parameter("copy_destination", copy_destination_str) || copy_destination_str.empty())
+        {
+            RCLCPP_FATAL(get_logger(), "Required parameter 'copy_destination' not set or is empty.");
+            return false;
+        }
+        base_copy_destination_ = copy_destination_str;
 
-// Override that accepts a std::filesystem::path
-void SystemDataRecorder::notify_new_file_to_copy(const std::filesystem::path & file_path)
-{
-  notify_new_file_to_copy(file_path.string());
-}
+        if (!this->get_parameter("max_file_size", max_file_size) || max_file_size <= 0)
+        {
+            RCLCPP_FATAL(get_logger(), "Required parameter 'max_file_size' not set or is <= 0.");
+            return false;
+        }
+        this->get_parameter("topic_names", topic_names);
+        this->get_parameter("topic_types", topic_types);
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// File-copying functionality
-///////////////////////////////////////////////////////////////////////////////////////////////////
+        if (topic_names.size() != topic_types.size())
+        {
+            RCLCPP_FATAL(get_logger(), "'topic_names' and 'topic_types' must have the same number of entries.");
+            return false;
+        }
 
-// Create the destination directory to copy bag files to
-// Returns true if the directory was created, false otherwise
-bool SystemDataRecorder::create_copy_destination()
-{
-  if (std::filesystem::exists(destination_directory_)) {
-    RCLCPP_ERROR(get_logger(), "Copy destination directory already exists");
-    return false;
-  }
-  RCLCPP_INFO(get_logger(), "Creating destination directory %s", destination_directory_.c_str());
-  return std::filesystem::create_directories(destination_directory_);
-}
+        for (size_t i = 0; i < topic_names.size(); ++i)
+        {
+            this->topics_and_types_[topic_names[i]] = topic_types[i];
+        }
 
-// Copy a bag file to the destination directory
-void SystemDataRecorder::copy_bag_file(const std::string & bag_file_name)
-{
-  RCLCPP_INFO(
-    get_logger(),
-    "Copying %s to %s",
-    bag_file_name.c_str(),
-    destination_directory_.c_str());
+        storage_options_.storage_id = "sqlite3";
+        storage_options_.max_bagfile_size = max_file_size;
+        storage_options_.max_cache_size = 100 * 1024 * 1024;
 
-  std::filesystem::copy(bag_file_name, destination_directory_);
-}
+        RCLCPP_INFO(get_logger(), "--- SystemDataRecorder Base Configuration ---");
+        RCLCPP_INFO(get_logger(), "* Bag Name Prefix: %s", base_bag_name_prefix_.c_str());
+        RCLCPP_INFO(get_logger(), "* Base Copy Destination: %s", base_copy_destination_.c_str());
+        RCLCPP_INFO(get_logger(), "* Max File Size: %d bytes", max_file_size);
+        RCLCPP_INFO(get_logger(), "* Topics to Record:");
+        if (this->topics_and_types_.empty())
+        {
+            RCLCPP_INFO(get_logger(), "  - None");
+        }
+        else
+        {
+            for (const auto &pair : this->topics_and_types_)
+            {
+                RCLCPP_INFO(get_logger(), "  - %s (%s)", pair.first.c_str(), pair.second.c_str());
+            }
+        }
+        RCLCPP_INFO(get_logger(), "-------------------------------------------");
 
-}  // namespace sdr
+        return true;
+    }
+
+    std::string SystemDataRecorder::generate_timestamp()
+    {
+        auto now = std::chrono::system_clock::now();
+        auto in_time_t = std::chrono::system_clock::to_time_t(now);
+        std::stringstream ss;
+        ss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d_%H-%M-%S");
+        return ss.str();
+    }
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    SystemDataRecorder::on_configure(const rclcpp_lifecycle::State &)
+    {
+        RCLCPP_INFO(get_logger(), "Configuring SDR. Creating main session directory.");
+
+        // Create the main timestamped directory for all bags from this run
+        session_destination_directory_ = base_copy_destination_ / ("sdr_session_" + generate_timestamp());
+
+        try
+        {
+            std::filesystem::create_directories(session_destination_directory_);
+        }
+        catch (const std::filesystem::filesystem_error &ex)
+        {
+            RCLCPP_ERROR(
+                get_logger(), "Could not create session directory '%s': %s",
+                session_destination_directory_.c_str(), ex.what());
+            return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
+        }
+        RCLCPP_INFO(
+            get_logger(), "All copied bags for this session will be stored in: %s",
+            session_destination_directory_.c_str());
+
+        copy_thread_ = std::make_shared<std::thread>([this]
+                                                     { this->copy_thread_main(); });
+        notify_state_change(SdrStateChange::PAUSED);
+        cleaned_up = false;
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    SystemDataRecorder::on_activate(const rclcpp_lifecycle::State &)
+    {
+        std::string bag_name = base_bag_name_prefix_ + "_" + generate_timestamp();
+        RCLCPP_INFO(get_logger(), "Activating. Starting new recording session: %s", bag_name.c_str());
+
+        // Set up paths for this specific recording session
+        current_bag_tmp_directory_ = std::filesystem::temp_directory_path() / bag_name;
+        current_bag_final_destination_ = session_destination_directory_ / bag_name;
+        storage_options_.uri = current_bag_tmp_directory_.string();
+
+        // Pre-emptively set the name of the first bag file. This ensures we always have a valid
+        // filename to copy, even if no bag split occurs.
+        last_bag_file_ = (current_bag_tmp_directory_ / (bag_name + "_0.db3")).string();
+
+        // Ensure the temporary directory is clean
+        if (std::filesystem::exists(current_bag_tmp_directory_))
+        {
+            std::filesystem::remove_all(current_bag_tmp_directory_);
+        }
+        std::filesystem::create_directories(current_bag_final_destination_);
+
+        writer_ = std::make_shared<rosbag2_cpp::Writer>(
+            std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
+
+        rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+        callbacks.write_split_callback =
+            [this](rosbag2_cpp::bag_events::BagSplitInfo &info)
+        {
+            last_bag_file_ = info.opened_file;
+            notify_new_file_to_copy({info.closed_file, current_bag_final_destination_});
+        };
+        writer_->add_event_callbacks(callbacks);
+        writer_->open(storage_options_, {rmw_get_serialization_format(), rmw_get_serialization_format()});
+
+        subscribe_to_topics();
+        notify_state_change(SdrStateChange::RECORDING);
+
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    SystemDataRecorder::on_deactivate(const rclcpp_lifecycle::State &)
+    {
+        RCLCPP_INFO(get_logger(), "Deactivating. Finalizing current bag.");
+        notify_state_change(SdrStateChange::PAUSED);
+        unsubscribe_from_topics();
+
+        if (writer_)
+        {
+            writer_.reset(); // Finalizes bag and writes metadata.yaml
+            notify_new_file_to_copy({last_bag_file_, current_bag_final_destination_});
+            notify_new_file_to_copy(
+                {current_bag_tmp_directory_ / "metadata.yaml", current_bag_final_destination_});
+        }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    SystemDataRecorder::on_cleanup(const rclcpp_lifecycle::State &state)
+    {
+        RCLCPP_INFO(get_logger(), "Cleaning up SDR.");
+        if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+        {
+            on_deactivate(state);
+        }
+
+        if (copy_thread_)
+        {
+            notify_state_change(SdrStateChange::FINISHED);
+            copy_thread_->join();
+            copy_thread_.reset();
+        }
+        cleaned_up = true;
+        RCLCPP_INFO(get_logger(), "Cleanup complete.");
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
+
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+    SystemDataRecorder::on_shutdown(const rclcpp_lifecycle::State &state)
+    {
+        RCLCPP_INFO(get_logger(), "Shutting down SDR.");
+        if (!cleaned_up)
+        {
+            on_cleanup(state);
+        }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // Bag recording functionality
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void SystemDataRecorder::subscribe_to_topics()
+    {
+        for (const auto &topic_with_type : topics_and_types_)
+        {
+            subscribe_to_topic(topic_with_type.first, topic_with_type.second);
+        }
+    }
+
+    void SystemDataRecorder::subscribe_to_topic(const std::string &topic, const std::string &type)
+    {
+        // Get the QoS offered by the topic for saving in the bag
+        auto offered_qos = get_serialised_offered_qos_for_topic(topic);
+        // Find out what QoS is most appropriate to use when subscribing to the topic
+        auto qos = get_appropriate_qos_for_topic(topic);
+
+        // The metadata to pass to the writer object so it can register the topic in the bag
+        auto topic_metadata = rosbag2_storage::TopicMetadata(
+            {
+                topic,                          // Topic name
+                type,                           // Topic type, e.g. "example_interfaces/msg/String"
+                rmw_get_serialization_format(), // The serialization format, most likely to be "CDR"
+                offered_qos                     // The offered QoS profile for the topic in YAML
+            });
+        // It is a good idea to create the topic in the writer prior to adding the subscription in case
+        // data arrives after subscribing and before the topic is created. Although we should be ignoring
+        // any data until the node is set to active, we maintain this good practice here for future
+        // maintainability.
+        writer_->create_topic(topic_metadata);
+
+        // Create a generic subscriber. A generic subscriber received message data in serialized form,
+        // which means that:
+        // - No de-serialization will take place, saving that processing time, and
+        // - The data type does not need to be known at compile time, so we don't need a templated
+        //   callback for when message data is received.
+        auto subscription = create_generic_subscription(
+            topic,
+            type,
+            qos,
+            [this, topic, type](std::shared_ptr<rclcpp::SerializedMessage> message)
+            {
+                // When a message is received, it should only be written to the bag if recording is not
+                // paused (i.e. the node lifecycle state is "active"). If recording is paused, the message is
+                // thrown away.
+                if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+                {
+                    writer_->write(message, topic, type, rclcpp::Clock(RCL_SYSTEM_TIME).now());
+                }
+            });
+        if (subscription)
+        {
+            subscriptions_.insert({topic, subscription});
+            RCLCPP_INFO(get_logger(), "Subscribed to topic '%s'", topic.c_str());
+        }
+        else
+        {
+            writer_->remove_topic(topic_metadata);
+            RCLCPP_ERROR(get_logger(), "Failed to subscribe to topic '%s'", topic.c_str());
+        }
+    }
+
+    std::string SystemDataRecorder::get_serialised_offered_qos_for_topic(const std::string &topic)
+    {
+        YAML::Node offered_qos_profiles;
+        auto endpoints = get_publishers_info_by_topic(topic);
+        for (const auto &endpoint : endpoints)
+        {
+            offered_qos_profiles.push_back(rosbag2_transport::Rosbag2QoS(endpoint.qos_profile()));
+        }
+        return YAML::Dump(offered_qos_profiles);
+    }
+
+    // Figure out the most appropriate QoS for a given topic. This method tries to decide if
+    // constrained QoS can be used, or if less-trustworthy QoS needs to be used to catch data from
+    // every publisher.
+    // Returns the QoS to use.
+    rclcpp::QoS SystemDataRecorder::get_appropriate_qos_for_topic(const std::string &topic)
+    {
+        auto qos = rclcpp::QoS(rmw_qos_profile_default.depth);
+
+        // Get the information about known publishers on this topic
+        auto endpoints = get_publishers_info_by_topic(topic);
+        if (endpoints.empty())
+        {
+            // There are not yet any publishers on the topic.
+            // Use the default QoS profile, as we do not know what publishers will use since there are not
+            // yet any publishers on this topic.
+            return qos;
+        }
+
+        // Count the number of reliable and transient-local publishers for the topic
+        size_t reliability_reliable_endpoints_count = 0;
+        size_t durability_transient_local_endpoints_count = 0;
+        for (const auto &endpoint : endpoints)
+        {
+            const auto &profile = endpoint.qos_profile().get_rmw_qos_profile();
+            if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE)
+            {
+                ++reliability_reliable_endpoints_count;
+            }
+            if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+            {
+                ++durability_transient_local_endpoints_count;
+            }
+        }
+
+        if (reliability_reliable_endpoints_count == endpoints.size())
+        {
+            // All publishers are reliable, so we can use the reliable QoS
+            qos.reliable();
+        }
+        else
+        {
+            if (reliability_reliable_endpoints_count > 0)
+            {
+                // There is a mix of QoS profiles amongst the publishers, so use the QoS setting that captures
+                // all of them
+                RCLCPP_WARN(
+                    get_logger(),
+                    "Some, but not all, publishers on topic \"%s\" are offering "
+                    "RMW_QOS_POLICY_RELIABILITY_RELIABLE. Falling back to "
+                    "RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT as it will connect to all publishers. Some "
+                    "messages from Reliable publishers could be dropped.",
+                    topic.c_str());
+            }
+            qos.best_effort();
+        }
+
+        if (durability_transient_local_endpoints_count == endpoints.size())
+        {
+            // All publishers are transient local, so we can use the transient local QoS
+            qos.transient_local();
+        }
+        else
+        {
+            if (durability_transient_local_endpoints_count > 0)
+            {
+                // There is a mix of QoS profiles amongst the publishers, so use the QoS setting that captures
+                // all of them
+                RCLCPP_WARN(
+                    get_logger(),
+                    "Some, but not all, publishers on topic \"%s\" are offering "
+                    "RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. Falling back to "
+                    "RMW_QOS_POLICY_DURABILITY_VOLATILE as it will connect to all publishers. Previously-"
+                    "published latched messages will not be retrieved.",
+                    topic.c_str());
+            }
+            qos.durability_volatile();
+        }
+
+        return qos;
+    }
+
+    void SystemDataRecorder::unsubscribe_from_topics()
+    {
+        // Make a note of the topics we are subscribed to
+        std::vector<rosbag2_storage::TopicMetadata> topics;
+        for (const auto &topic_with_type : topics_and_types_)
+        {
+            topics.push_back(rosbag2_storage::TopicMetadata(
+                {topic_with_type.first,
+                 topic_with_type.second,
+                 rmw_get_serialization_format(),
+                 ""}));
+        }
+        // Unsubscribing happens automatically when the subscription objects are destroyed
+        subscriptions_.clear();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // File-copying thread
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void SystemDataRecorder::copy_thread_main()
+    {
+        RCLCPP_INFO(get_logger(), "Copy thread: Starting");
+        SdrStateChange current_state = SdrStateChange::PAUSED;
+        std::queue<FileCopyJob> local_files_to_copy;
+
+        while (current_state != SdrStateChange::FINISHED)
+        {
+            {
+                std::unique_lock<std::mutex> lock(copy_thread_mutex_);
+                copy_thread_wake_cv_.wait(
+                    lock, [this]
+                    { return copy_thread_should_wake(); });
+
+                if (state_msg_ != SdrStateChange::NO_CHANGE)
+                {
+                    current_state = state_msg_;
+                    state_msg_ = SdrStateChange::NO_CHANGE;
+                }
+                local_files_to_copy.swap(files_to_copy_);
+            }
+
+            while (!local_files_to_copy.empty())
+            {
+                FileCopyJob job = local_files_to_copy.front();
+                local_files_to_copy.pop();
+                copy_bag_file(job);
+            }
+        }
+
+        // After thread is finished, one last check for any remaining files
+        while (!files_to_copy_.empty())
+        {
+            copy_bag_file(files_to_copy_.front());
+            files_to_copy_.pop();
+        }
+        // And clean up the final temporary directory if it exists
+        if (std::filesystem::exists(current_bag_tmp_directory_))
+        {
+            std::filesystem::remove_all(current_bag_tmp_directory_);
+        }
+        RCLCPP_INFO(get_logger(), "Copy thread: Exiting");
+    }
+
+    bool SystemDataRecorder::copy_thread_should_wake()
+    {
+        return state_msg_ != SdrStateChange::NO_CHANGE || !files_to_copy_.empty();
+    }
+
+    void SystemDataRecorder::notify_state_change(SdrStateChange new_state)
+    {
+        {
+            std::lock_guard<std::mutex> lock(copy_thread_mutex_);
+            state_msg_ = new_state;
+        }
+        copy_thread_wake_cv_.notify_one();
+    }
+
+    void SystemDataRecorder::notify_new_file_to_copy(const FileCopyJob &job)
+    {
+        {
+            std::lock_guard<std::mutex> lock(copy_thread_mutex_);
+            files_to_copy_.push(job);
+        }
+        copy_thread_wake_cv_.notify_one();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // File-copying functionality
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void SystemDataRecorder::copy_bag_file(const FileCopyJob &job)
+    {
+        if (job.source_path.empty() || !std::filesystem::exists(job.source_path))
+        {
+            RCLCPP_WARN(get_logger(), "Skipping copy of non-existent source file: %s", job.source_path.c_str());
+            return;
+        }
+        RCLCPP_INFO(
+            get_logger(), "Copying %s to %s",
+            job.source_path.c_str(), job.destination_path.c_str());
+        try
+        {
+            std::filesystem::copy(job.source_path, job.destination_path);
+        }
+        catch (const std::filesystem::filesystem_error &e)
+        {
+            RCLCPP_ERROR(
+                get_logger(), "Failed to copy '%s' to '%s': %s",
+                job.source_path.c_str(), job.destination_path.c_str(), e.what());
+        }
+    }
+
+} // namespace sdr

--- a/src/system_data_recorder.cpp
+++ b/src/system_data_recorder.cpp
@@ -22,22 +22,15 @@
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_transport/recorder.hpp"
 
-int main(int argc, char * argv[])
+int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
-
-  auto topics_and_types = std::unordered_map<std::string, std::string>();
-  topics_and_types.insert({"/chatter", "std_msgs/msg/String"});
-  auto sdr_component = std::make_shared<sdr::SystemDataRecorder>(
-    "sdr",
-    rclcpp::NodeOptions(),
-    "test_bag",
-    "copied_bag",
-    100000,
-    topics_and_types);
-
   rclcpp::executors::SingleThreadedExecutor exec;
-  exec.add_node(sdr_component->get_node_base_interface());
+
+  // Create the node. It will load its parameters automatically.
+  auto sdr_node = std::make_shared<sdr::SystemDataRecorder>(rclcpp::NodeOptions());
+
+  exec.add_node(sdr_node->get_node_base_interface());
   exec.spin();
 
   rclcpp::shutdown();


### PR DESCRIPTION
This commit refactors the node to use parameters loaded from YAML instead of hardcoded values. The lifecycle logic has been updated so activate/deactivate now starts and stops unique, timestamped recording sessions, allowing for multiple bags per run. 